### PR TITLE
Make it work with musl/pcre

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
     - uses: 'actions/checkout@v3'
+    - uses: 'lhotari/action-upterm@v1'
+      with: {"limit-access-to-actor": true}
     - run: 'sudo apt-get install -y zsh libpcre2-dev'
     - run: './configure --with-pcre'
     - run: 'CHECK=-v make check'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,30 @@
+name: 'test'
+
 on:
   push:         {"branches": ["master"]}
   pull_request: {"branches": ["master"]}
 
 jobs:
-  test-gnu:
+  gnu:
     runs-on: 'ubuntu-latest'
     steps:
     - uses: 'actions/checkout@v3'
     - run: 'sudo apt-get install -y zsh'
+    - run: './configure'
     - run: 'CHECK=-v make check'
 
-  test-musl:
+  pcre:
     runs-on: 'ubuntu-latest'
     steps:
     - uses: 'actions/checkout@v3'
-    - run: 'sudo apt-get install -y zsh musl-tools'
+    - run: 'sudo apt-get install -y zsh libpcre2-dev'
+    - run: './configure --with-pcre'
+    - run: 'CHECK=-v make check'
+
+  musl:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'actions/checkout@v3'
+    - run: 'sudo apt-get install -y zsh musl-tools libpcre2-dev'
+    - run: 'CC=musl-gcc ./configure'
     - run: 'CC=musl-gcc CHECK=-v make check'

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /egrep
 /fgrep
 /rgrep
+/config.mk

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@ CFLAGS ?= -O2
 
 .PHONY: all clean check install install-zgrep
 
+include config.mk
+
 all:
 	${CC} -std=c99 -pedantic -Wall -D_GNU_SOURCE=1 ${CFLAGS} ${LDFLAGS} -o grep *.c
 
 clean:
-	rm -f grep egrep fgrep rgrep
+	rm -f grep egrep fgrep rgrep config.mk
 
 check: all
 	@./test.zsh ${CHECK}

--- a/README.md
+++ b/README.md
@@ -21,5 +21,7 @@ Only `[efr]?grep` is installed by default; use `make install-zgrep` to install
 
 `make check` runs the tests (`zsh` is required).
 
+On musl it will compile against PCRE because musl doesn't support REG_STARTEND.
+
 [freebsd-src]: https://github.com/freebsd/freebsd-src/tree/main/usr.bin/grep
 [FreeBSD 13]: https://cgit.freebsd.org/src/commit/?id=b82a9ec5f53e

--- a/configure
+++ b/configure
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -e
+
+test_reg_startend() {
+	tmp=$(mktemp)
+	cat >$tmp.c <<-EOF
+		#include <regex.h>
+
+		int main() {
+		#ifdef REG_STARTEND
+			return 0;
+		#else
+			return 1;
+		#endif
+		}
+	EOF
+
+	${CC:-cc} $tmp.c -o $tmp.out
+	$tmp.out
+	r=$?
+	rm $tmp $tmp.c $tmp.out
+	return $r
+}
+
+usage() {
+	cat <<-EOF
+		Options:
+
+		  --with-pcre  Use pcre2-posix rather than regex.h from libc. Required
+		               for some platforms where regex.h doesn't support
+		               REG_STARTEND (e.g. musl).
+
+		               Default is to auto-detect if libc supports it.
+	EOF
+}
+
+pcre=0
+for f in "$@"; do
+	case $f in
+		-h|-help|--help)        usage; exit 0 ;;
+		-with-pcre|--with-pcre) pcre=1 ;;
+		*)
+			echo >&2 "unknown flag: $f"
+			echo
+			usage
+			exit 1
+	esac
+done
+
+echo '# Platform-specific options' >config.mk
+if [ $pcre -eq 1 ] || ! test_reg_startend; then
+	echo "using pcre2 regex.h"
+
+	echo '' >>config.mk
+	echo '# Use pcre2 because REG_STARTEND is not defined (e.g. on musl)' >>config.mk
+	echo 'CFLAGS  += -DWITH_PCRE=1 `pcre2-config --cflags-posix`'         >>config.mk
+	echo 'LDFLAGS += `pcre2-config --libs-posix`'                         >>config.mk
+else
+	echo "using libc regex.h"
+fi

--- a/grep.h
+++ b/grep.h
@@ -31,7 +31,12 @@
  */
 
 #include <limits.h>
-#include <regex.h>
+#ifdef WITH_PCRE
+#  include <pcre2posix.h>
+#else
+#  include <regex.h>
+#endif
+
 #include <stdbool.h>
 #include <stdio.h>
 
@@ -43,7 +48,7 @@ extern const char		*errstr[];
 #define	GREP_BASIC	1
 #define	GREP_EXTENDED	2
 
-#if !defined(REG_NOSPEC) && !defined(REG_LITERAL)
+#if (!defined(REG_NOSPEC) && !defined(REG_LITERAL)) || defined(WITH_PCRE)
 #define WITH_INTERNAL_NOSPEC
 #endif
 

--- a/update.sh
+++ b/update.sh
@@ -8,9 +8,10 @@ done
 for f in fts.c fts.h; do
 	curl -sLO https://raw.githubusercontent.com/void-linux/musl-fts/master/$f
 done
-curl -sLO 'https://gitlab.freedesktop.org/libbsd/libbsd/-/raw/main/src/progname.c?ref_type=heads'
 
 sed -Ei '/^#include <(bzlib|zlib|sys\/cdefs|sys\/queue)\.h>$/d' *.c *.h
 sed -i  's/#include <fts.h>/#include "fts.h"/' *.c
 sed -i  '/grep\.h/a #include "freebsd.h"' file.c grep.c queue.c util.c
 sed -i '/^#include "config\.h"$/d; s/^#if !defined(HAVE_DECL_MAX).*/#ifndef MAX/' fts.c
+sed -i 's/^#include <regex.h>$/#ifdef WITH_PCRE\n#  include <pcre2posix.h>\n#else\n#  include <regex.h>\n#endif\n/' grep.h
+sed -i 's/^#if !defined(REG_NOSPEC) && !defined(REG_LITERAL)$/#if (!defined(REG_NOSPEC) \&\& !defined(REG_LITERAL)) || defined(WITH_PCRE)/' grep.h


### PR DESCRIPTION
`REG_STARTEND` is not in musl, so short of rewriting a bunch of code using pcre2 seems the easiest way to make it work.